### PR TITLE
[libos] and [pal]: bring back `init_std_handles`

### DIFF
--- a/libos/src/libos_init.c
+++ b/libos/src/libos_init.c
@@ -430,7 +430,7 @@ noreturn void libos_init(const char* const* argv, const char* const* envp) {
     RUN_INIT(init_threading);
     RUN_INIT(init_mount_root);
     RUN_INIT(init_mount);
-    //RUN_INIT(init_std_handles);
+    RUN_INIT(init_std_handles);
 
     char** expanded_argv = NULL;
     RUN_INIT(init_exec_handle, argv, &expanded_argv);

--- a/pal/src/host/svsm/pal_console.c
+++ b/pal/src/host/svsm/pal_console.c
@@ -10,29 +10,61 @@
 
 #include "api.h"
 #include "pal.h"
+#include "pal_svsm.h"
 #include "pal_error.h"
 #include "pal_internal.h"
+#include "perm.h"
+#include "spinlock.h"
 
 static int console_open(PAL_HANDLE* handle, const char* type, const char* uri,
                         enum pal_access access, pal_share_flags_t share,
                         enum pal_create_mode create, pal_stream_options_t options) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+    __UNUSED(uri);
+    __UNUSED(share);
+    __UNUSED(create);
+    __UNUSED(options);
+
+    if (strcmp(type, URI_TYPE_CONSOLE))
+        return -PAL_ERROR_INVAL;
+
+    if (access != PAL_ACCESS_RDONLY && access != PAL_ACCESS_WRONLY)
+        return -PAL_ERROR_INVAL;
+
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(console));
+    if (!hdl)
+        return -PAL_ERROR_NOMEM;
+
+    hdl->hdr.type = PAL_TYPE_CONSOLE;
+    hdl->flags = access == PAL_ACCESS_RDONLY ? PAL_HANDLE_FD_READABLE : PAL_HANDLE_FD_WRITABLE;
+    hdl->console.fd = access == PAL_ACCESS_RDONLY ? /*host stdin*/0 : /*host stdout*/1;
+
+    *handle = hdl;
+    return 0;
 }
 
 static int64_t console_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
+    log_error("attempting console_read");
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 static int64_t console_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
+    log_error("attempting console_write");
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 static void console_destroy(PAL_HANDLE handle) {
     /* noop */
+    assert(handle->hdr.type == PAL_TYPE_CONSOLE);
+    free(handle);
 }
 
 static int console_flush(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+    assert(handle->hdr.type == PAL_TYPE_CONSOLE);
+
+    if (!(handle->flags & PAL_HANDLE_FD_WRITABLE))
+        return -PAL_ERROR_DENIED;
+
+    return 0; /* no-op */
 }
 
 struct handle_ops g_console_ops = {

--- a/pal/src/host/svsm/pal_host.h
+++ b/pal/src/host/svsm/pal_host.h
@@ -42,4 +42,18 @@ typedef struct {
         uint32_t signaled;
         bool auto_clear;
     } event;
+
+    struct {
+        PAL_IDX fd;
+    } console;
+
 }* PAL_HANDLE;
+
+/* These two flags indicate whether the underlying host fd of `PAL_HANDLE` is readable and/or
+ * writable respectively. If none of these is set, then the handle has no host-level fd. */
+#define PAL_HANDLE_FD_READABLE  1
+#define PAL_HANDLE_FD_WRITABLE  2
+/* Set if an error was seen on this handle. */
+#define PAL_HANDLE_FD_ERROR     4
+/* Set if a hang-up was seen on this handle. */
+#define PAL_HANDLE_FD_HANG_UP   8


### PR DESCRIPTION
[libos] and [pal]: re-enable the `init_std_handles` in the libos initialization process

This PR performs the following:
- brings back the initialization of `stdin`, `stdout`, `stderr` at the `libos_init`
- opens the respective FDs in the console_open to be found later in the execution process
- introduces the console filed in the svsm `PAL_HANDLE`
- defines the required FD flags
- `console_read` and `console_write` emit a `log_error` and return `NOT_IMPLEMENTED` for now
